### PR TITLE
FIX not adding timestamps to already signed files

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -65,7 +65,7 @@ class Document < ApplicationRecord
 
   def set_add_timestamp
     parameters['level'] = parameters['level'].gsub(/BASELINE_B/, 'BASELINE_T') if parameters['level']
-    parameters['level'] = 'T' unless parameters['level']
+    parameters['level'] = 'T' unless parameters['level'] && parameters['level'] != 'B'
     save!
   end
 


### PR DESCRIPTION
Pri podpisovaní už podpísaného súboru sa nedala pridať pečiatka, lebo tam bola takáto maličká chyba. Toto už je ok a otestované.