### PR TITLE
Fix `/integration-devices`

### DIFF
--- a/app/controllers/api/v1/integration_devices_controller.rb
+++ b/app/controllers/api/v1/integration_devices_controller.rb
@@ -3,11 +3,12 @@ class Api::V1::IntegrationDevicesController < ApiController
 
   def index
     @devices = @integration.devices
+    render :index
   end
 
   def destroy
     @integration.devices.delete(Device.find(params.require(:id)))
-    render :head
+    head 204
   end
 
   private


### PR DESCRIPTION
GET `/integration-devices` vracia 204 aj ked by som nejake devices mal tak som sa to pokusil opravit (s pomocou kamosa, stale nemam rozbehane ruby ☹️ )